### PR TITLE
Default to empty string instead of undefined/null

### DIFF
--- a/lib/environment/LocalStorageKeyEnvironment.js
+++ b/lib/environment/LocalStorageKeyEnvironment.js
@@ -15,7 +15,7 @@ LocalStorageKeyEnvironment.prototype = Object.create(Environment.prototype);
 LocalStorageKeyEnvironment.prototype.constructor = LocalStorageKeyEnvironment;
 
 LocalStorageKeyEnvironment.prototype.getPath = function() {
-  return window.localStorage.getItem(this.key);
+  return window.localStorage.getItem(this.key) || '';
 };
 
 LocalStorageKeyEnvironment.prototype.pushState = function(path, navigation) {


### PR DESCRIPTION
The RouterMixin tests for isString. Perhaps getPath should always return a string then?